### PR TITLE
Supporting B2G platform

### DIFF
--- a/python/feninit.py
+++ b/python/feninit.py
@@ -235,9 +235,9 @@ class FenInit(gdb.Command):
         print 'Done'
 
         # get parent/child(ren) pid's
-        pidParent = next((x.split()[1]
+        pidParent = next((x.split()[0]
                 for x in pkgProcs if CHILD_EXECUTABLE not in x))
-        pidChild = [x.split()[1]
+        pidChild = [x.split()[0]
                 for x in pkgProcs if CHILD_EXECUTABLE in x]
         pidChildParent = pidParent
 


### PR DESCRIPTION
Since B2G platform does not launch the Gecko application by the user.  We need let user to choice whether to launch an application or just to attach an existing process.  This request let user to start a debugging session without launching with by setting feninit.default.no_launch python variable in gdbinit.  It also fix a bug of string splitting function.  It may caused by changes of semantic following newer versions of Python (2.6.6/2.6.7).
