### PR TITLE
Make the default launch class for the Android app configurable

### DIFF
--- a/gdbinit
+++ b/gdbinit
@@ -44,6 +44,11 @@ python import feninit, tracebt, fastload, adblog, updater
 
 #python feninit.default.jdwp_port = 5040
 
+# set feninit.default.launchclass to the entry point class for
+#   the application to test
+
+#python feninit.default.launchclass = "App"
+
 # set feninit.default.env to set environment variables for
 #   debugging Fennec; only applicable when specifically using the
 #   "Debug Fennec with env vars and args" option

--- a/python/feninit.py
+++ b/python/feninit.py
@@ -466,8 +466,10 @@ class FenInit(gdb.Command):
     def _launch(self, pkg):
         sys.stdout.write('Launching %s... ' % pkg)
         sys.stdout.flush()
+        launchclass = self.launchclass if hasattr(self, 'launchclass') else "App"
+
         # always launch in case the activity is not in foreground
-        args = ['shell', 'am', 'start', '-n', pkg + '/.App', '-W']
+        args = ['shell', 'am', 'start', '-n', pkg + '/.' + launchclass, '-W']
         extraArgs = []
         kill = False
         if hasattr(self, '_env') and self._env:


### PR DESCRIPTION
b2gdroid uses `Launcher` for the alternate Home Screen. This makes utils a little more configurable for edge cases like this.