### PR TITLE
Create destination directory before copying app_process.

### DIFF
--- a/python/feninit.py
+++ b/python/feninit.py
@@ -157,6 +157,7 @@ class FenInit(gdb.Command):
             dstpath = os.path.join(self.libdir, name.replace('/', os.sep))
             if os.path.exists(dstpath):
                 return os.path.basename(name)
+            os.makedirs(os.path.dirname(dstpath))
 
             try:
                 adb.pull('/' + name, dstpath)


### PR DESCRIPTION
Prevents the adb.pull() failing with a permission error
the first time it's run for a new device.